### PR TITLE
fixed: 깃헙이슈_#53: DaumpostcodeEmbed 메소드 사용시 Document.write() 가문제가 됩니다.

### DIFF
--- a/src/DaumPostcodeEmbed.tsx
+++ b/src/DaumPostcodeEmbed.tsx
@@ -26,18 +26,6 @@ interface State {
   hasError: boolean;
 }
 
-/**
- * 1. 깃헙이슈_#53: DaumpostcodeEmbed 메소드 사용시 Document.write() 가 문제가 됩니다.
- * 2. 에러메세지: caught TypeError: Cannot read properties of null (reading 'document').
- * 3. 원인: `loadPostcode` 함수가 두번 실행되어 발생하는 문제입니다.
- * * React StrictMode에서는 의도적으로 라이프사이클 메소드가 두 번 호출되게 설계되어 있습니다.
- * * 이는 개발 과정에서 부작용(side-effects)이 발생하는 것을 감지하고 문제를 미리 찾아낼 수 있도록 하는 목적이 있습니다.
- * 4. 해결: 의도적으로 componentDidMount시 `loadPostcode` 함수가 1번만 호출하도록 변수 `mount`를 추가하여, mount값이 false 일때만 `loadPostcode`를 실행하면 해결됩니다.
- * @see =================== 변경 내역 ==================
- * [작성자][작업일시] - 내용
- * [HK1211][2023-05-28 Sunday 00:48:08] - 최초작성
- */
-
 const defaultErrorMessage = <p>현재 Daum 우편번호 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해주세요.</p>;
 
 const defaultStyle = {
@@ -53,7 +41,19 @@ const defaultProps = {
 
 class DaumPostcodeEmbed extends Component<DaumPostcodeEmbedProps, State> {
   static defaultProps = defaultProps;
-  private mount = false;
+
+  /**
+   * 1. 깃헙이슈_#53: DaumpostcodeEmbed 메소드 사용시 Document.write() 가 문제가 됩니다.
+   * 2. 에러메세지: caught TypeError: Cannot read properties of null (reading 'document').
+   * 3. 원인: `loadPostcode` 함수가 두번 실행되어 발생하는 문제입니다.
+   * * React StrictMode에서는 의도적으로 라이프사이클 메소드가 두 번 호출되게 설계되어 있습니다.
+   * * 이는 개발 과정에서 부작용(side-effects)이 발생하는 것을 감지하고 문제를 미리 찾아낼 수 있도록 하는 목적이 있습니다.
+   * 4. 해결: 의도적으로 componentDidMount시 `loadPostcode` 함수가 1번만 호출하도록 변수 `mount`를 추가하여, mount값이 false 일때만 `loadPostcode`를 실행하면 해결됩니다.
+   * @see =================== 변경 내역 ==================
+   * [작성자][작업일시] - 내용
+   * [HK1211][2023-05-28 Sunday 00:48:08] - 최초작성
+   */
+  private mounted = false;
 
   wrap = createRef<HTMLDivElement>();
 
@@ -66,9 +66,9 @@ class DaumPostcodeEmbed extends Component<DaumPostcodeEmbedProps, State> {
     const { scriptUrl } = this.props;
 
     if (!scriptUrl) return;
-    if (!this.mount) {
-      this.mount = true; // react@18 부터 development 환경에서 React.StrictMode 사용시 출력되는 문제해결.
+    if (!this.mounted) {
       loadPostcode(scriptUrl).then(initiate).catch(onError);
+      this.mounted = true; // react@18 부터 development 환경에서 React.StrictMode 사용시 출력되는 문제해결.
     }
   }
 

--- a/src/DaumPostcodeEmbed.tsx
+++ b/src/DaumPostcodeEmbed.tsx
@@ -37,7 +37,7 @@ interface State {
  * [작성자][작업일시] - 내용
  * [HK1211][2023-05-28 Sunday 00:48:08] - 최초작성
  */
-let mount = false;
+
 const defaultErrorMessage = <p>현재 Daum 우편번호 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해주세요.</p>;
 
 const defaultStyle = {
@@ -53,6 +53,7 @@ const defaultProps = {
 
 class DaumPostcodeEmbed extends Component<DaumPostcodeEmbedProps, State> {
   static defaultProps = defaultProps;
+  private mount = false;
 
   wrap = createRef<HTMLDivElement>();
 
@@ -65,8 +66,8 @@ class DaumPostcodeEmbed extends Component<DaumPostcodeEmbedProps, State> {
     const { scriptUrl } = this.props;
 
     if (!scriptUrl) return;
-    if (!mount) {
-      mount = true; // react@18 부터 development 환경에서 React.StrictMode 사용시 출력되는 문제해결.
+    if (!this.mount) {
+      this.mount = true; // react@18 부터 development 환경에서 React.StrictMode 사용시 출력되는 문제해결.
       loadPostcode(scriptUrl).then(initiate).catch(onError);
     }
   }

--- a/src/DaumPostcodeEmbed.tsx
+++ b/src/DaumPostcodeEmbed.tsx
@@ -26,6 +26,18 @@ interface State {
   hasError: boolean;
 }
 
+/**
+ * 1. 깃헙이슈_#53: DaumpostcodeEmbed 메소드 사용시 Document.write() 가 문제가 됩니다.
+ * 2. 에러메세지: caught TypeError: Cannot read properties of null (reading 'document').
+ * 3. 원인: `loadPostcode` 함수가 두번 실행되어 발생하는 문제입니다.
+ * * React StrictMode에서는 의도적으로 라이프사이클 메소드가 두 번 호출되게 설계되어 있습니다.
+ * * 이는 개발 과정에서 부작용(side-effects)이 발생하는 것을 감지하고 문제를 미리 찾아낼 수 있도록 하는 목적이 있습니다.
+ * 4. 해결: 의도적으로 componentDidMount시 `loadPostcode` 함수가 1번만 호출하도록 변수 `mount`를 추가하여, mount값이 false 일때만 `loadPostcode`를 실행하면 해결됩니다.
+ * @see =================== 변경 내역 ==================
+ * [작성자][작업일시] - 내용
+ * [HK1211][2023-05-28 Sunday 00:48:08] - 최초작성
+ */
+let mount = false;
 const defaultErrorMessage = <p>현재 Daum 우편번호 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해주세요.</p>;
 
 const defaultStyle = {
@@ -53,7 +65,10 @@ class DaumPostcodeEmbed extends Component<DaumPostcodeEmbedProps, State> {
     const { scriptUrl } = this.props;
 
     if (!scriptUrl) return;
-    loadPostcode(scriptUrl).then(initiate).catch(onError);
+    if (!mount) {
+      mount = true; // react@18 부터 development 환경에서 React.StrictMode 사용시 출력되는 문제해결.
+      loadPostcode(scriptUrl).then(initiate).catch(onError);
+    }
   }
 
   initiate = (Postcode: PostcodeConstructor) => {


### PR DESCRIPTION
…. #53

에러해결: caught TypeError: Cannot read properties of null (reading 'document')

원인: DaumPostcodeEmbed.tsx.tsx. 파일의 `componentDidMount` 내부의 `loadPostcode` 함수가 두번 실행되어 발생하는 문제입니다.
 * * React StrictMode에서는 의도적으로 라이프사이클 메소드가 두 번 호출되게 설계되어 있습니다.
 * * 이는 개발 과정에서 부작용(side-effects)이 발생하는 것을 감지하고 문제를 미리 찾아낼 수 있도록 하는 목적이 있습니다.
 * * 참조: https://legacy.reactjs.org/docs/strict-mode.html

해결: 의도적으로 componentDidMount시 `loadPostcode` 함수가 1번만 호출하도록 변수 `mount`를 추가하여, mount값이 false 일때만 `loadPostcode`를 실행하면 해결됩니다.