### PR TITLE
Add 'minWidth' property to Postcode constructor

### DIFF
--- a/src/loadPostcode.ts
+++ b/src/loadPostcode.ts
@@ -79,6 +79,7 @@ export interface PostcodeOptions {
   onclose?: (state: State) => void;
   onsearch?: (search: Search) => void;
   width?: string | number;
+  minWidth?: number;
   height?: string | number;
   animation?: boolean;
   focusInput?: boolean;

--- a/src/loadPostcode.ts
+++ b/src/loadPostcode.ts
@@ -130,21 +130,21 @@ const loadPostcode = (function () {
   let promise: Promise<PostcodeConstructor> | null = null;
 
   return function (url: string = postcodeScriptUrl): Promise<PostcodeConstructor> {
-    if( promise ) return promise;
+    if (promise) return promise;
 
     promise = new Promise((resolve, reject) => {
       const script = document.createElement('script');
       script.src = url;
       script.onload = () => {
-        if( window?.daum?.Postcode ) {
+        if (window?.daum?.Postcode) {
           return resolve(window.daum.Postcode);
         }
-        reject(new Error('Script is loaded successfully, but cannot find Postcode module. Check your scriptURL property.'))
+        reject(new Error('Script is loaded successfully, but cannot find Postcode module. Check your scriptURL property.'));
       };
       script.onerror = (error) => reject(error);
       script.id = scriptId;
       document.body.appendChild(script);
-    })
+    });
 
     return promise;
   };


### PR DESCRIPTION
- 포멧팅 수정
- 우편번호 생성자 옵션에 ['minWidth'](https://github.com/daumPostcode/QnA/blob/master/PATCHNOTE.md#2024-11-12) 추가