### PR TITLE
DaumPostcodeEmbedProps 인터페이스가 EmbedOptions를 확장하도록 수정

### DIFF
--- a/src/DaumPostcodeEmbed.tsx
+++ b/src/DaumPostcodeEmbed.tsx
@@ -1,8 +1,9 @@
 import React, { Component, createRef, CSSProperties } from 'react';
-import loadPostcode, { postcodeScriptUrl, PostcodeConstructor, PostcodeOptions } from './loadPostcode';
+import loadPostcode, { postcodeScriptUrl, PostcodeConstructor, PostcodeOptions, EmbedOptions } from './loadPostcode';
 
 export interface DaumPostcodeEmbedProps
-  extends Omit<PostcodeOptions, 'oncomplete' | 'onresize' | 'onclose' | 'onsearch' | 'width' | 'height'> {
+  extends Omit<PostcodeOptions, 'oncomplete' | 'onresize' | 'onclose' | 'onsearch' | 'width' | 'height'>,
+    Omit<EmbedOptions, 'q'> {
   onComplete?: PostcodeOptions['oncomplete'];
   onResize?: PostcodeOptions['onresize'];
   onClose?: PostcodeOptions['onclose'];
@@ -12,7 +13,6 @@ export interface DaumPostcodeEmbedProps
   defaultQuery?: string;
   errorMessage?: string | React.ReactNode;
   scriptUrl?: string;
-  autoClose?: boolean;
 }
 /**
  * @deprecated


### PR DESCRIPTION
## 변경 사항

이 PR은 타입 일관성을 개선하고 중복을 줄이기 위해 `DaumPostcodeEmbedProps` 인터페이스를 수정합니다.

- `DaumPostcodeEmbedProps` 인터페이스에서 명시적인 `autoClose` 속성 제거
- `Omit<EmbedOptions, 'q'>`를 확장하여 `autoClose` 속성을 상속받도록 수정
- loadPostcode에서 `EmbedOptions` 가져오기 추가

### 원인

`autoClose` 속성이 `DaumPostcodeEmbedProps`와 `EmbedOptions` 사이에 중복되어 있었습니다.

### 해결

 `Omit<EmbedOptions, 'q'>`를 확장함으로써 이 속성을 `EmbedOptions`에서 직접 상속받고 더 나은 타입 일관성을 유지할 수 있습니다.
